### PR TITLE
Miscellaneous fixes required to pass AuriStorFS tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,13 +12,14 @@ mech_sanon_la_CFLAGS   = -Werror -Wall -Wunused-parameter @KRB5_CFLAGS@
 mech_sanon_la_CPPFLAGS = -DGSSAPI_CALLCONV=KRB5_CALLCONV -DBUILD_GSSSANON_LIB -I$(srcdir)/x25519 -I$(srcdir)
 mech_sanon_la_DEPENDENCIES = $(srcdir)/mech_sanon.exports
 mech_sanon_la_LDFLAGS  = -avoid-version -module -export-symbols $(srcdir)/mech_sanon.exports -no-undefined @KRB5_LDFLAGS@
-mech_sanon_la_LIBADD   = @KRB5_LIBS@ 
+mech_sanon_la_LIBADD   = @KRB5_LIBS@
 
 mech_sanon_la_SOURCES =    		\
 	accept_sec_context.c		\
 	acquire_cred.c			\
 	add_cred.c			\
 	canonicalize_name.c		\
+	compare_name.c			\
 	context_time.c			\
 	crypto.c			\
 	delete_sec_context.c		\
@@ -26,6 +27,7 @@ mech_sanon_la_SOURCES =    		\
 	display_name.c			\
 	display_status.c		\
 	duplicate_name.c		\
+	export_cred.c			\
 	export_name.c			\
 	export_sec_context.c		\
 	external.c			\
@@ -35,8 +37,8 @@ mech_sanon_la_SOURCES =    		\
 	init_sec_context.c		\
 	inquire_attrs_for_mech.c	\
 	inquire_context.c		\
-	inquire_cred.c			\
 	inquire_cred_by_mech.c		\
+	inquire_cred.c			\
 	inquire_mechs_for_name.c	\
 	inquire_names_for_mech.c	\
 	inquire_sec_context_by_oid.c	\

--- a/compare_name.c
+++ b/compare_name.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020, AuriStor, Inc.
+ * Copyright (c) 2019-2024, AuriStor, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,8 +33,8 @@
 
 OM_uint32 GSSAPI_CALLCONV
 gss_compare_name(OM_uint32 *minor,
-		 gss_name_t name1,
-		 gss_name_t name2,
+		 gss_name_t name1 __attribute__((__unused__)),
+		 gss_name_t name2 __attribute__((__unused__)),
 		 int *name_equal)
 {
     *minor = 0;

--- a/mech_sanon.exports
+++ b/mech_sanon.exports
@@ -8,10 +8,12 @@ gss_delete_sec_context
 gss_display_name
 gss_display_status
 gss_duplicate_name
+gss_export_cred
 gss_export_name
 gss_export_sec_context
 gss_get_mic
 gss_get_mic_iov
+gss_import_cred
 gss_import_name
 gss_import_sec_context
 gss_init_sec_context


### PR DESCRIPTION
- Add source files that were missing from Makefile.am and therefore were not compiled
- Add the __unused__ attribute to gss_compare_name parameters
- Export gss_export_cred and gss_import_cred

